### PR TITLE
Add scripts/idr0079_voxel_sizes.sh and .tsv

### DIFF
--- a/scripts/idr0079_voxel_sizes.sh
+++ b/scripts/idr0079_voxel_sizes.sh
@@ -1,0 +1,32 @@
+# membrane_only
+omero metadata pixelsize --x 0.0992103 --y 0.0992103 --z 0.2245383 Dataset:10260
+
+# membranes_nuclei
+omero metadata pixelsize --x 0.1024427 --y 0.1024427 --z 0.2245383 Dataset:10262
+
+# membranes_actin
+omero metadata pixelsize --x 0.1024427 --y 0.1024427 --z 0.2245383 Dataset:10264
+
+# membranes_cisgolgi
+omero metadata pixelsize --x 0.0992103 --y 0.0992103 --z 0.22 Dataset:10266
+
+# membranes_earlyendo
+omero metadata pixelsize --x 0.0992103 --y 0.0992103 --z 0.22 Dataset:10268
+
+# membranes_recendo
+omero metadata pixelsize --x 0.0992103 --y 0.0992103 --z 0.2245383 Dataset:10270
+
+# membranes_tgn
+omero metadata pixelsize --x 0.0992103 --y 0.0992103 --z 0.22 Dataset:10272
+
+# membranes_transgolgi
+omero metadata pixelsize --x 0.0992103 --y 0.0992103 --z 0.22 Dataset:10274
+
+# membranes_atoh1a
+omero metadata pixelsize --x 0.0992103 --y 0.0992103 --z 0.2245383 Dataset:10276
+
+# membranes_lyso
+omero metadata pixelsize --x 0.0992103 --y 0.0992103 --z 0.2245383 Dataset:10278
+
+# membranes_pea3fish
+omero metadata pixelsize --x 0.0851964 --y 0.0851964 --z 0.1867357 Dataset:10280

--- a/scripts/idr0079_voxel_sizes.tsv
+++ b/scripts/idr0079_voxel_sizes.tsv
@@ -1,0 +1,12 @@
+name_in_my_db	original_idr_experiment	merged_idr_experiment	name_in_idr	x [microns]	y [microns]	z [microns]
+membrane_only	experimentA	experimentA	membranes	0.0992103	0.0992103	0.2245383
+NLS-tdTomato	experimentB	experimentA	membranes_nuclei	0.1024427	0.1024427	0.2245383
+tagRFPt-UtrCH	experimentC	experimentA	membranes_actin	0.1024427	0.1024427	0.2245383
+mkate2-GM130(rat)	experimentD	experimentA	membranes_cisgolgi	0.0992103	0.0992103	0.2200000
+mKate2-Rab5a	experimentE	experimentA	membranes_earlyendo	0.0992103	0.0992103	0.2200000
+mKate2-Rab11a	experimentF	experimentA	membranes_recendo	0.0992103	0.0992103	0.2245383
+CDMPR-tagRFPt	experimentG	experimentA	membranes_tgn	0.0992103	0.0992103	0.2200000
+B4GalT1(1-55Q)-tagRFPt	experimentH	experimentA	membranes_transgolgi	0.0992103	0.0992103	0.2200000
+atoh1a_dtomato	experimentI	experimentA	membranes_atoh1a	0.0992103	0.0992103	0.2245383
+LysoTracker	experimentJ	experimentA	membranes_lyso	0.0992103	0.0992103	0.2245383
+pea3 smFISH	experimentK	experimentB	membranes_pea3fish	0.0851964	0.0851964	0.1867357


### PR DESCRIPTION
Based on table of pixel sizes for each Dataset (see .tsv) I ran the commands in the `idr0079_voxel_sizes.sh` on idr-next.

cc @sbesson 